### PR TITLE
Using similar language as to what was discussed - Added a simple

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,12 @@
-This software has been licensed by Wayne State University to Merit Network,
-Inc., with the express purpose of releasing under an open source license.
+Copyright (C) 2012-2020 Wayne State University
 
-Copyright, Use of Name, and Disclaimer.
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written
+agreement is hereby granted, provided that the above copyright notice
+and this paragraph and the following three paragraphs appear in all
+copies.
 
- The software [or “Portions of the software”] incorporated herein is owned
+The software [or “Portions of the software”] incorporated herein is owned
 by Wayne State University.  All Rights Reserved.
 
 The name of Wayne State University, or any logos, seals, insignia, or other
@@ -21,3 +24,5 @@ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
 PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS PROVIDED “AS IS”.  WAYNE
 STATE UNIVERSITY HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
 ENHANCEMENTS, OR MODIFICATIONS.
+
+


### PR DESCRIPTION
date-range (C) notice "above" as used in other licenses, and preserved
the "above" wording accordingly.